### PR TITLE
add pip install example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,12 @@ Note that this apps works with django >= 1.4 only.
 [Video displaying interaction with the widget](https://www.youtube.com/watch?v=H4xqku-BPBU)
 
 ## Usage
-First, add `'admin_enhancer'` to your `INSTALLED_APPS` to avoid getting
+
+The recommended way to install the Debug Toolbar is via [pip](http://www.pip-installer.org/):
+
+    $ pip install django-admin-enhancer
+
+Add `'admin_enhancer'` to your `INSTALLED_APPS` to avoid getting
 `TemplateDoesNotExist` errors.
 
 Make sure to mix `EnhancedModelAdminMixin` when dealing with


### PR DESCRIPTION
I thought it’d be useful to explicitly point out the pypi name of the project (even if it’s just the title of the project). It would have saved me a minute of double checking. What do you think?
