### PR TITLE
fix for Django 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - 2.6
   - 2.7
-  - 3.2
   - 3.3
   - 3.4
 
@@ -12,25 +11,29 @@ env:
   - DJANGO=1.5
   - DJANGO=1.6
   - DJANGO=1.7
+  - DJANGO=1.8
+  - DJANGO=1.9
 
 matrix:
   exclude:
     - python: 2.6
       env: DJANGO=1.7
+    - python: 2.6
+      env: DJANGO=1.8
+    - python: 2.6
+      env: DJANGO=1.9
     - python: 3.2
       env: DJANGO=1.4
     - python: 3.3
       env: DJANGO=1.4
+    - python: 3.3
+      env: DJANGO=1.9
     - python: 3.4
       env: DJANGO=1.4
     - python: 3.4
       env: DJANGO=1.5
     - python: 3.4
       env: DJANGO=1.6
-  allow_failures:
-    - python: 3.2
-    - python: 3.3
-    - python: 3.4
 
 install:
   - pip install tox coveralls

--- a/admin_enhancer/admin.py
+++ b/admin_enhancer/admin.py
@@ -30,13 +30,13 @@ class EnhancedAdminMixin(object):
         """Sets is_popup context variable to hide admin header."""
         if not extra_context:
             extra_context = {}
-        extra_context['is_popup'] = request.REQUEST.get('_popup', 0)
+        extra_context['is_popup'] = request.POST.get('_popup', 0)
         return super(EnhancedAdminMixin, self).delete_view(request, object_id, extra_context)
 
 
 class EnhancedModelAdminMixin(EnhancedAdminMixin):
     def response_change(self, request, obj):
-        if '_popup' in request.REQUEST:
+        if '_popup' in request.POST:
             return render_to_response(
                 'admin_enhancer/dismiss-change-related-popup.html', {'obj': obj}
             )
@@ -45,7 +45,7 @@ class EnhancedModelAdminMixin(EnhancedAdminMixin):
 
     def delete_view(self, request, object_id, extra_context=None):
         delete_view_response = super(EnhancedModelAdminMixin, self).delete_view(request, object_id, extra_context)
-        if (request.POST and '_popup' in request.REQUEST and
+        if ('_popup' in request.POST and
                 isinstance(delete_view_response, HttpResponseRedirect)):
             return render_to_response(
                 'admin_enhancer/dismiss-delete-related-popup.html', {'object_id': object_id}

--- a/setup.py
+++ b/setup.py
@@ -42,5 +42,5 @@ setup(
     include_package_data=True,
     keywords=['django admin foreign'],
     packages=find_packages(exclude=['tests', 'tests.*']),
-    install_requires=['django>=1.4,<1.8'],
+    install_requires=['django>=1.4,<1.10'],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,9 +2,9 @@
 args_are_paths = false
 envlist =
     {py26}-{1.4,1.5,1.6},
-    {py27}-{1.4,1.5,1.6,1.7},
-    {py32,py33}-{1.6,1.7},
-    py34-{1.7}
+    {py27}-{1.4,1.5,1.6,1.7,1.8,1.9},
+    {py32,py33}-{1.6,1.7,1.8,1.9},
+    py34-{1.7,1.8,1.9}
 
 [testenv]
 basepython =
@@ -28,3 +28,5 @@ deps =
     1.5: django-discover-runner
     1.6: Django>=1.6,<1.7
     1.7: Django>=1.7,<1.8
+    1.8: Django>=1.8,<1.9
+    1.9: Django>=1.9,<1.10


### PR DESCRIPTION
run tests on Dj 1.8 and 1.9
moving Python 3 tests out of allow failures mode
dropping Python 3.2 testing (as it is not supported by coverage package)
